### PR TITLE
chore: complete repo hygiene cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,20 +3,26 @@
 
 # macOS
 .DS_Store
+Thumbs.db
 
 # Environment variables
-.env*
-.env.production
+.env
+.env.*
+!.env.example
 
 # Database files
 *.db
+*.db-journal
 *.db-shm
 *.db-wal
 
 # Test results
 test-results/
+playwright-report/
+coverage/
 
 # Build artifacts
 *.tsbuildinfo
 node_modules/
 dist/
+build/

--- a/n8drive/.gitignore
+++ b/n8drive/.gitignore
@@ -1,24 +1,36 @@
 node_modules/
 .DS_Store
+Thumbs.db
 npm-debug.log*
 /tmp/
 data/publiclogic-audit.ndjson
+
+# Environment variables
 .env
-.env.local
-.env.production
+.env.*
+!.env.example
 **/.env.local
 
 # Build artifacts
 dist/
 **/dist/
+build/
 prod-test/
 *.tsbuildinfo
 
 # SQLite database files - development data
 **/data/*.db
+**/data/*.db-journal
 **/data/*.db-shm
 **/data/*.db-wal
 **/test-data/*.db
+*.db
+*.db-journal
+
+# Test outputs
+test-results/
+playwright-report/
+coverage/
 
 # Temporary files
 web/.tmp_webhook_secret.txt

--- a/n8drive/TEST_STRUCTURE.md
+++ b/n8drive/TEST_STRUCTURE.md
@@ -1,0 +1,75 @@
+# Test Directory Structure
+
+The PuddleJumper monorepo uses a dual test directory structure:
+
+## Directory Organization
+
+### `/n8drive/test/` - Legacy Unit Tests
+Contains older unit tests and integration tests that were written before the monorepo refactoring.
+
+**Contents:**
+- `governance.test.ts` - Governance/approval workflow tests
+- `idempotency-store.test.ts` - Idempotency tracking tests  
+- `pj-popout.test.ts` - Popout window tests
+- `server.test.ts` - Server integration tests
+- `sqlite-maintenance.test.ts` - SQLite maintenance utility tests
+- `tests/runtime.spec.ts` - Runtime configuration tests (nested legacy)
+
+**Note:** This directory is kept for backward compatibility. New tests should go in package-specific test directories.
+
+### `/n8drive/tests/` - E2E and Visual Regression Tests
+Contains Playwright-based end-to-end tests and visual snapshot tests added in V1.
+
+**Contents:**
+- `e2e/` - End-to-end user flow tests
+  - `prr-e2e.spec.ts` - PRR submission and workflow tests
+  - `smoke.spec.ts` - Basic smoke tests
+- `e2e-smoke.spec.ts` - Additional smoke tests
+- `login.spec.ts` - Authentication flow tests
+- `snapshots/` - Visual regression tests
+  - `visual.spec.ts` - Playwright visual snapshots
+
+### Package-Specific Test Directories
+Each package has its own `/test/` directory for unit tests:
+
+- `/n8drive/packages/core/test/` - Core utilities unit tests
+- `/n8drive/apps/logic-commons/test/` - Logic Commons unit tests
+- `/n8drive/apps/puddlejumper/test/` - PuddleJumper app unit tests
+  - Contains 428 passing tests (27 test files)
+  - 2 stubbed PRR tests (documented in `prr.api.test.skip.txt`)
+
+## Test Commands
+
+```bash
+# Run all unit tests
+cd n8drive
+pnpm --filter @publiclogic/puddlejumper run test
+
+# Run E2E tests
+cd n8drive
+pnpm run test:e2e
+
+# Run visual regression tests
+cd n8drive
+pnpm run test:visual
+```
+
+## Rationale
+
+**Why two top-level test directories?**
+
+1. **Historical:** `/test/` existed before monorepo refactoring
+2. **Separation of Concerns:** 
+   - `/test/` = Legacy integration tests (vitest)
+   - `/tests/` = E2E and visual tests (playwright)
+   - Package-specific `/test/` = New unit tests (vitest)
+3. **Build Tools:** Different test runners (vitest vs playwright) work better with separate directories
+
+## Future Consolidation
+
+For V2+, consider consolidating to:
+- Move `/test/` contents to `/apps/puddlejumper/test/` (unit tests)
+- Keep `/tests/` for E2E/visual (different test runner)
+- Remove nested `/test/tests/` (legacy artifact)
+
+This is tracked as part of ongoing repo hygiene but is not critical for V1 functionality.


### PR DESCRIPTION
Completes remaining items from issue #21.

## Changes

✅ **Updated .gitignore files** (root and n8drive)
- Added comprehensive patterns for test artifacts (playwright-report/, coverage/)
- Added *.db-journal for SQLite journal files
- Added Thumbs.db for Windows
- Added build/ directory

✅ **Documented test directory structure**
- Created TEST_STRUCTURE.md explaining dual test directory setup
- Documented /test/ (legacy unit tests) vs /tests/ (E2E/visual)
- Explained package-specific test directories
- Noted future consolidation opportunity

✅ **Verified package structure**
- Confirmed n8drive/ is workspace root (no root package.json - correct)

✅ **Verified tests still passing**
- 428 passing, 2 skipped (documented)
- All builds successful

## Previously Complete (from PR #23)
- ✅ Remove .env.production from git
- ✅ Add root README.md
- ✅ Delete .DS_Store and zero-byte files
- ✅ Remove duplicate pnpm files
- ✅ Add LICENSE file
- ✅ Close stale PRs
- ✅ Delete stale branches

## Not Found / Already Clean
- Security contact references (no security@example.com found - already good)

Closes #21