### PR TITLE
chore: stabilize post-merge bootstrap/auth workflows

### DIFF
--- a/docs/DEVELOPER.md
+++ b/docs/DEVELOPER.md
@@ -96,3 +96,9 @@ Optional overrides:
 When running bootstrap/tests, logs are captured at:
 - `.pj-test-logs/bootstrap.log`
 - `.pj-test-logs/pj-tests.log`
+
+## 7. Known pitfalls
+
+- `better-sqlite3` / `NODE_MODULE_VERSION` mismatch errors usually mean modules were built under a different Node runtime.
+- Run `source ~/.nvm/nvm.sh && nvm use 20` before ad-hoc `pnpm` commands.
+- If mismatch errors persist, rerun `bash scripts/bootstrap.sh` to rebuild native modules under Node 20.

--- a/n8drive/.github/workflows/ci-release-v1.yml
+++ b/n8drive/.github/workflows/ci-release-v1.yml
@@ -38,6 +38,10 @@ jobs:
       
       - name: Run unit tests
         run: pnpm -r test --filter puddlejumper
+        env:
+          JWT_SECRET: ci-test-secret-min-32-chars-long-0000000000
+          AUTH_ISSUER: puddle-jumper
+          AUTH_AUDIENCE: puddle-jumper-api
       
       - name: Upload coverage
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
- align `n8drive/.github/workflows/ci-release-v1.yml` unit-test env with auth contract (`AUTH_ISSUER` / `AUTH_AUDIENCE`)
- include CI `JWT_SECRET` for deterministic auth-related tests in that workflow
- add a **Known pitfalls** section in `docs/DEVELOPER.md` for Node runtime mismatch (`NODE_MODULE_VERSION`) and required `nvm use 20` workflow

## Validation
- `bash scripts/bootstrap.sh` (workspace build/tests + contract check)
- `source ~/.nvm/nvm.sh && nvm use 20 && cd n8drive/apps/puddlejumper && pnpm test -- --reporter=verbose`
- result: `27 passed | 2 skipped` test files, no auth-wide 401 regressions

## Notes
- `setup-admin` import scope remains targeted to `admin.test.ts` and `tier-enforcement.test.ts` only (not global Vitest setup).
- `.pj-test-logs/` remains git-ignored and untracked.
