### PR TITLE
rehydrate: RBAC enforcement for chain templates

### DIFF
--- a/n8drive/apps/puddlejumper/src/api/routes/chainTemplates.ts
+++ b/n8drive/apps/puddlejumper/src/api/routes/chainTemplates.ts
@@ -29,7 +29,7 @@ export function createChainTemplateRoutes(opts: ChainTemplateRouteOptions): expr
   const { chainStore } = opts;
 
   // ── List templates (workspace-scoped) ────────────────────────────────
-  router.get("/chain-templates", requireAuthenticated(), (req, res) => {
+  router.get("/chain-templates", requireAuthenticated(), requireRole("owner", "admin"), (req, res) => {
     const auth = getAuthContext(req);
     const correlationId = getCorrelationId(res);
     if (!auth) { res.status(401).json({ success: false, correlationId, error: "Unauthorized" }); return; }
@@ -38,7 +38,7 @@ export function createChainTemplateRoutes(opts: ChainTemplateRouteOptions): expr
   });
 
   // ── Get single template (workspace-scoped) ───────────────────────────
-  router.get("/chain-templates/:id", requireAuthenticated(), (req, res) => {
+  router.get("/chain-templates/:id", requireAuthenticated(), requireRole("owner", "admin"), (req, res) => {
     const auth = getAuthContext(req);
     const correlationId = getCorrelationId(res);
     if (!auth) { res.status(401).json({ success: false, correlationId, error: "Unauthorized" }); return; }
@@ -178,7 +178,8 @@ export function createChainTemplateRoutes(opts: ChainTemplateRouteOptions): expr
     if (inUseCount > 0) {
       res.status(409).json({
         success: false, correlationId,
-        error: `Template is in use by ${inUseCount} active chain(s) and cannot be deleted`,
+        error: "Template in use by active chains",
+        activeCount: inUseCount,
       });
       return;
     }


### PR DESCRIPTION
## Summary
Rehydrates the RBAC chain-template scope from stale PR #34 onto current `main`.

### Changes
- Enforce admin/owner access for template read endpoints:
  - `GET /api/chain-templates`
  - `GET /api/chain-templates/:id`
- Keep mutation paths admin-only.
- Normalize delete-in-use response payload to include deterministic shape:
  - `error: "Template in use by active chains"`
  - `activeCount`
- Update tests to assert admin-only template access and response shape.

Supersedes: #34
Tracking map: #48

## Validation
- `bash scripts/bootstrap.sh`
- `source ~/.nvm/nvm.sh && nvm use 20 && cd n8drive/apps/puddlejumper && pnpm test -- --reporter=verbose`
- Result: `27 passed | 2 skipped` files, `429 passed | 2 skipped` tests.
