### PR TITLE
rehydrate: OS/UI smoke reliability and sync hardening

### DIFF
--- a/n8drive/ops/NEXT-STEPS.md
+++ b/n8drive/ops/NEXT-STEPS.md
@@ -1,0 +1,50 @@
+# PuddleJumper Next Steps
+
+## Current baseline (Feb 2026)
+
+- `main` is green with Node 20 and deterministic bootstrap flow.
+- Bootstrap/auth stabilization has landed.
+- Rehydration is in progress via focused PRs from fresh branches.
+
+## Active rehydration tracks
+
+1. **RBAC/API safety**
+   - Chain template admin-only access + tests
+   - Targeted step decision validation (`stepId`) + negative tests
+
+2. **Async policy provider adoption**
+   - Promise-based `PolicyProvider` contract
+   - Governance and engine callsites updated to `await`
+
+3. **OS/UI stability**
+   - Playwright smoke locator hardening
+   - Playbook sync script shell-safety hardening (`nullglob`)
+
+## Merge gate policy
+
+- **Backend-only changes** (`n8drive/**`, backend tests/docs): GitHub CI must pass.
+- **UI/site surface changes** (`publiclogic-os-ui/**` or `publiclogic-site/**`): GitHub CI + relevant Vercel status must pass.
+
+## Immediate execution order
+
+1. Merge rehydrated RBAC/template access PR.
+2. Merge rehydrated `stepId` hardening PR.
+3. Merge async `PolicyProvider` contract PR.
+4. Merge OS/UI smoke + sync hardening PR.
+5. Close stale Copilot-era PRs with links to replacement PRs.
+
+## Optional follow-up bundle
+
+If needed, split observability/playbook backlog into separate PRs:
+
+- backend metrics + alerts
+- playbook content sync
+- workflow/CI automation
+
+Each should be independently mergeable and keep lockfile churn out of scope.
+
+## Operator notes
+
+- Use Node 20 (`nvm use 20`) before ad-hoc test runs.
+- If native module mismatch occurs, rerun `bash scripts/bootstrap.sh`.
+- Keep `.pj-test-logs/` local-only for diagnostics.

--- a/scripts/sync-playbooks.sh
+++ b/scripts/sync-playbooks.sh
@@ -16,6 +16,7 @@
 #   ./scripts/sync-playbooks.sh --check  # dry-run: report drift, exit 1 if out of sync
 
 set -euo pipefail
+shopt -s nullglob
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 

--- a/tests/e2e/tools-smoke.spec.ts
+++ b/tests/e2e/tools-smoke.spec.ts
@@ -5,14 +5,14 @@ test.describe('Tools page - Governance card', () => {
     await page.goto('/#/tools');
 
     await expect(page.locator('text=Governance')).toBeVisible();
-    await expect(page.locator('a', { hasText: 'Agenda' })).toBeVisible();
-    await expect(page.locator('a', { hasText: 'Playbooks' })).toBeVisible();
+    await expect(page.locator('a:has-text("Agenda")')).toBeVisible();
+    await expect(page.locator('a:has-text("Playbooks")')).toBeVisible();
   });
 
   test('Agenda button links to agenda page', async ({ page }) => {
     await page.goto('/#/tools');
 
-    const agendaLink = page.locator('a', { hasText: 'Agenda' });
+    const agendaLink = page.locator('a:has-text("Agenda")');
     await expect(agendaLink).toBeVisible();
     await expect(agendaLink).toHaveAttribute('href', '#/agenda');
   });
@@ -20,7 +20,7 @@ test.describe('Tools page - Governance card', () => {
   test('Playbooks button links to Logicville playbook', async ({ page }) => {
     await page.goto('/#/tools');
 
-    const playbooksLink = page.locator('a', { hasText: 'Playbooks' });
+    const playbooksLink = page.locator('a:has-text("Playbooks")');
     await expect(playbooksLink).toBeVisible();
     await expect(playbooksLink).toHaveAttribute('href', /09-logicville-living-agenda/);
   });
@@ -30,9 +30,9 @@ test.describe('Tools page - Governance card', () => {
 
     // The admin button only appears when puddlejumper.adminUrl is set in config.
     // This test verifies the link target is correct if the button is present.
-    const adminBtn = page.locator('a', { hasText: 'PuddleJumper Admin' });
-    const count = await adminBtn.count();
-    test.skip(count === 0, 'PuddleJumper Admin button not configured — skipping');
+    const adminBtn = page.locator('a:has-text("PuddleJumper Admin")');
+    const isVisible = await adminBtn.isVisible().catch(() => false);
+    test.skip(!isVisible, 'PuddleJumper Admin button not configured — skipping');
     await expect(adminBtn).toHaveAttribute('href', /pj\/admin/);
   });
 });


### PR DESCRIPTION
## Summary
Rehydrates the low-risk OS/UI stability slice from stale PRs #44/#45 (plus selected smoke behavior fixes) onto current `main`.

### Changes
- Harden `scripts/sync-playbooks.sh` against empty globs by enabling `nullglob`.
- Make Playwright tools smoke locators more robust and less flaky in `tests/e2e/tools-smoke.spec.ts`.
- Add concise `n8drive/ops/NEXT-STEPS.md` execution roadmap (without lockfile churn).

Supersedes: #44, #45 (selected scope)
Tracking map: #48

## Scope guard
- Excludes lockfile churn.
- Excludes broad playbook/workflow bundles from #40/#42.

## Validation
- `bash scripts/bootstrap.sh`
- `source ~/.nvm/nvm.sh && nvm use 20 && cd n8drive/apps/puddlejumper && pnpm test -- --reporter=verbose`
- Result: `27 passed | 2 skipped` files, `428 passed | 2 skipped` tests.
