### PR TITLE
chore: rehydrate minimal observability + playbook assets (phase E)

### DIFF
--- a/n8drive/apps/puddlejumper/src/engine/approvalMetrics.ts
+++ b/n8drive/apps/puddlejumper/src/engine/approvalMetrics.ts
@@ -191,10 +191,18 @@ export const METRIC = {
 
   // Gauges
   PENDING_GAUGE: "approval_pending_gauge",
+  CHAIN_STEP_PENDING_GAUGE: "approval_chain_step_pending_gauge",
 
   // Histograms
   APPROVAL_TIME: "approval_time_seconds",
   DISPATCH_LATENCY: "dispatch_latency_seconds",
+  CHAIN_STEP_TIME: "approval_chain_step_time_seconds",
+
+  // Chain counters
+  CHAIN_STEPS_TOTAL: "approval_chain_steps_total",
+  CHAIN_STEP_DECIDED: "approval_chain_step_decided_total",
+  CHAIN_COMPLETED: "approval_chain_completed_total",
+  CHAIN_REJECTED: "approval_chain_rejected_total",
 } as const;
 
 /** Human-readable HELP strings for each metric (used in Prometheus output). */
@@ -209,6 +217,12 @@ export const METRIC_HELP: Record<string, string> = {
   [METRIC.CONSUME_CAS_CONFLICT]:"CAS conflicts when acquiring dispatch lock (double-dispatch prevented)",
   dispatch_retry_total:          "Total retry attempts across all dispatcher dispatch calls",
   [METRIC.PENDING_GAUGE]:       "Current number of approvals in pending state",
+  [METRIC.CHAIN_STEP_PENDING_GAUGE]: "Current number of chain steps in active (awaiting decision) state",
   [METRIC.APPROVAL_TIME]:       "Time in seconds from approval creation to decision",
   [METRIC.DISPATCH_LATENCY]:    "Time in seconds for dispatch plan execution",
+  [METRIC.CHAIN_STEP_TIME]:     "Time in seconds from chain step activation to decision",
+  [METRIC.CHAIN_STEPS_TOTAL]:   "Total chain steps created across all approvals",
+  [METRIC.CHAIN_STEP_DECIDED]:  "Total chain steps decided",
+  [METRIC.CHAIN_COMPLETED]:     "Total approval chains fully approved (all steps passed)",
+  [METRIC.CHAIN_REJECTED]:      "Total approval chains rejected at any step",
 };

--- a/n8drive/apps/puddlejumper/test/chain-metrics.test.ts
+++ b/n8drive/apps/puddlejumper/test/chain-metrics.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { ApprovalMetrics, METRIC, METRIC_HELP } from "../src/engine/approvalMetrics.js";
+
+describe("Chain metrics constants", () => {
+  it("defines chain metric names", () => {
+    expect(METRIC.CHAIN_STEPS_TOTAL).toBe("approval_chain_steps_total");
+    expect(METRIC.CHAIN_STEP_DECIDED).toBe("approval_chain_step_decided_total");
+    expect(METRIC.CHAIN_COMPLETED).toBe("approval_chain_completed_total");
+    expect(METRIC.CHAIN_REJECTED).toBe("approval_chain_rejected_total");
+    expect(METRIC.CHAIN_STEP_PENDING_GAUGE).toBe("approval_chain_step_pending_gauge");
+    expect(METRIC.CHAIN_STEP_TIME).toBe("approval_chain_step_time_seconds");
+  });
+
+  it("has HELP strings for chain metrics", () => {
+    expect(METRIC_HELP[METRIC.CHAIN_STEPS_TOTAL]).toBeTruthy();
+    expect(METRIC_HELP[METRIC.CHAIN_STEP_DECIDED]).toBeTruthy();
+    expect(METRIC_HELP[METRIC.CHAIN_COMPLETED]).toBeTruthy();
+    expect(METRIC_HELP[METRIC.CHAIN_REJECTED]).toBeTruthy();
+    expect(METRIC_HELP[METRIC.CHAIN_STEP_PENDING_GAUGE]).toBeTruthy();
+    expect(METRIC_HELP[METRIC.CHAIN_STEP_TIME]).toBeTruthy();
+  });
+});
+
+describe("Chain metrics instrumentation", () => {
+  let metrics: ApprovalMetrics;
+
+  beforeEach(() => {
+    metrics = new ApprovalMetrics();
+  });
+
+  it("tracks chain counters and gauges", () => {
+    metrics.increment(METRIC.CHAIN_STEPS_TOTAL, 3);
+    metrics.increment(METRIC.CHAIN_STEP_DECIDED, 2);
+    metrics.increment(METRIC.CHAIN_COMPLETED);
+    metrics.increment(METRIC.CHAIN_REJECTED);
+    metrics.setGauge(METRIC.CHAIN_STEP_PENDING_GAUGE, 5);
+
+    const snap = metrics.snapshot();
+    expect(snap.find((entry) => entry.name === METRIC.CHAIN_STEPS_TOTAL)?.value).toBe(3);
+    expect(snap.find((entry) => entry.name === METRIC.CHAIN_STEP_DECIDED)?.value).toBe(2);
+    expect(snap.find((entry) => entry.name === METRIC.CHAIN_COMPLETED)?.value).toBe(1);
+    expect(snap.find((entry) => entry.name === METRIC.CHAIN_REJECTED)?.value).toBe(1);
+    expect(snap.find((entry) => entry.name === METRIC.CHAIN_STEP_PENDING_GAUGE)?.value).toBe(5);
+  });
+
+  it("tracks chain step latency histogram and emits Prometheus output", () => {
+    metrics.observe(METRIC.CHAIN_STEP_TIME, 120);
+    metrics.observe(METRIC.CHAIN_STEP_TIME, 3600);
+
+    const snap = metrics.snapshot();
+    expect(snap.find((entry) => entry.name === `${METRIC.CHAIN_STEP_TIME}_count`)?.value).toBe(2);
+    expect(snap.find((entry) => entry.name === `${METRIC.CHAIN_STEP_TIME}_sum`)?.value).toBe(3720);
+
+    const prometheus = metrics.prometheus(METRIC_HELP);
+    expect(prometheus).toContain(`# HELP ${METRIC.CHAIN_STEP_TIME}`);
+    expect(prometheus).toContain(`# TYPE ${METRIC.CHAIN_STEP_TIME} histogram`);
+    expect(prometheus).toContain(`${METRIC.CHAIN_STEP_TIME}_count 2`);
+  });
+
+  it("reset clears chain metrics", () => {
+    metrics.increment(METRIC.CHAIN_STEPS_TOTAL, 10);
+    metrics.setGauge(METRIC.CHAIN_STEP_PENDING_GAUGE, 3);
+    metrics.observe(METRIC.CHAIN_STEP_TIME, 60);
+    metrics.reset();
+    expect(metrics.snapshot()).toHaveLength(0);
+  });
+});

--- a/n8drive/ops/alerts/approval-alerts.yml
+++ b/n8drive/ops/alerts/approval-alerts.yml
@@ -7,7 +7,10 @@
 #   approvals_created_total, approvals_approved_total, approvals_rejected_total,
 #   approval_pending_gauge, approval_time_seconds, dispatch_success_total,
 #   dispatch_failure_total, dispatch_latency_seconds,
-#   consume_for_dispatch_conflict_total
+#   consume_for_dispatch_conflict_total,
+#   approval_chain_steps_total, approval_chain_step_decided_total,
+#   approval_chain_completed_total, approval_chain_rejected_total,
+#   approval_chain_step_pending_gauge, approval_chain_step_time_seconds
 #
 # Tune thresholds to your SLA. These are conservative starting points.
 
@@ -101,3 +104,17 @@ groups:
             {{ $value }} approvals created but zero approved/rejected.
             Approval pipeline may be stalled.
           runbook: https://github.com/97n8/puddlejumper/blob/main/ops/runbooks/approvals.md
+
+      # ── Chain step stuck > 24h ───────────────────────────────────────────
+      - alert: ChainStepStuck24h
+        expr: approval_chain_step_pending_gauge > 0 and increase(approval_chain_step_decided_total[24h]) == 0
+        for: 30m
+        labels:
+          severity: warn
+        annotations:
+          summary: "Chain step(s) pending with no decisions in 24h"
+          description: >-
+            {{ $value }} chain steps are active but no step has been decided
+            in the last 24 hours. A chain may be stalled; check approver
+            availability and step role assignments.
+          runbook: https://github.com/97n8/puddlejumper/blob/main/ops/runbooks/chain-stuck.md

--- a/n8drive/ops/grafana/puddlejumper-approvals-dashboard.json
+++ b/n8drive/ops/grafana/puddlejumper-approvals-dashboard.json
@@ -313,6 +313,104 @@
         },
         "overrides": []
       }
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 22 },
+      "id": 8,
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom" },
+        "tooltip": { "show": true }
+      },
+      "title": "Chain Steps Created / Decided / Completed / Rejected (rate, 5m)",
+      "type": "timeseries",
+      "targets": [
+        {
+          "expr": "rate(approval_chain_steps_total[5m])",
+          "legendFormat": "steps created",
+          "refId": "A"
+        },
+        {
+          "expr": "rate(approval_chain_step_decided_total[5m])",
+          "legendFormat": "steps decided",
+          "refId": "B"
+        },
+        {
+          "expr": "rate(approval_chain_completed_total[5m])",
+          "legendFormat": "chains completed",
+          "refId": "C"
+        },
+        {
+          "expr": "rate(approval_chain_rejected_total[5m])",
+          "legendFormat": "chains rejected",
+          "refId": "D"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": { "unit": "req/s", "min": 0 },
+        "overrides": []
+      }
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 22 },
+      "id": 9,
+      "options": {
+        "tooltip": { "show": true },
+        "legend": { "displayMode": "list", "placement": "bottom" }
+      },
+      "title": "Pending Chain Steps (gauge)",
+      "type": "timeseries",
+      "targets": [
+        {
+          "expr": "approval_chain_step_pending_gauge",
+          "legendFormat": "active steps",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "min": 0,
+          "decimals": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "orange", "value": 5 },
+              { "color": "red", "value": 15 }
+            ]
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 22 },
+      "id": 10,
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom" },
+        "tooltip": { "show": true }
+      },
+      "title": "Chain Step Decision Time p50 & p95",
+      "type": "timeseries",
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.5, sum(rate(approval_chain_step_time_seconds_bucket[5m])) by (le))",
+          "legendFormat": "p50",
+          "refId": "A"
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(approval_chain_step_time_seconds_bucket[5m])) by (le))",
+          "legendFormat": "p95",
+          "refId": "B"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": { "unit": "s", "min": 0 },
+        "overrides": []
+      }
     }
   ],
   "refresh": "10s",

--- a/n8drive/ops/runbooks/chain-stuck.md
+++ b/n8drive/ops/runbooks/chain-stuck.md
@@ -1,0 +1,49 @@
+# Chain Step Stuck > 24h Runbook
+
+## Alert
+
+- Name: `ChainStepStuck24h`
+- Condition: `approval_chain_step_pending_gauge > 0` and no decisions in 24h
+- Severity: `warn`
+
+## Meaning
+
+A chain step is active and waiting, but no step decisions were recorded in the last 24h.
+
+Likely causes:
+- Required approver role has no active user.
+- Approver was not notified.
+- Chain template role mapping is incorrect.
+
+## Investigate
+
+1. Find active steps:
+
+```sql
+SELECT id, approval_id, required_role, label, created_at
+FROM approval_chain_steps
+WHERE status = 'active'
+ORDER BY created_at ASC;
+```
+
+2. Find impacted approvals:
+
+```sql
+SELECT a.id, a.action_intent, a.operator_id, a.workspace_id, a.created_at
+FROM approvals a
+JOIN approval_chain_steps s ON s.approval_id = a.id
+WHERE s.status = 'active' AND a.status = 'pending';
+```
+
+3. Confirm users exist for each `required_role`.
+4. Check `/pj/admin#approvals` for stalled approvals and chain state.
+
+## Resolve
+
+- If approver exists: notify them and request decision.
+- If template role is wrong: fix template, reject stuck approval, resubmit.
+- If approver unavailable: admin can decide via `POST /api/approvals/:id/decide`.
+
+## Silence guidance
+
+Silence only during planned maintenance windows or when no active workflows are expected.


### PR DESCRIPTION
## Scope
Minimal-risk Phase E rehydrate from old backlog, limited to observability + runbook assets:

- add chain-step metric constants/help entries in `approvalMetrics`
- add focused tests in `test/chain-metrics.test.ts`
- add `ChainStepStuck24h` alert
- add Grafana panels for chain-step metrics
- add `ops/runbooks/chain-stuck.md`

## Explicitly out of scope
- no behavioral rewrites in approvals/governance routes
- no lockfile churn
- no generated artifacts

## Validation
- `bash scripts/bootstrap.sh` ✅
- `source ~/.nvm/nvm.sh && nvm use 20 && cd n8drive/apps/puddlejumper && pnpm test -- --reporter=verbose` ✅
- `cd n8drive && pnpm run check:pj-contract` ✅

## Notes
This PR keeps production API behavior unchanged and is intentionally additive.
