### PR TITLE
fix: stabilize staging sqlite data path and startup writability

### DIFF
--- a/docs/DEVELOPER.md
+++ b/docs/DEVELOPER.md
@@ -102,3 +102,5 @@ When running bootstrap/tests, logs are captured at:
 - `better-sqlite3` / `NODE_MODULE_VERSION` mismatch errors usually mean modules were built under a different Node runtime.
 - Run `source ~/.nvm/nvm.sh && nvm use 20` before ad-hoc `pnpm` commands.
 - If mismatch errors persist, rerun `bash scripts/bootstrap.sh` to rebuild native modules under Node 20.
+- Staging SQLite `CANTOPEN` usually means `/app/data` is not writable by the `node` user; verify mount + Fly env DB paths and check entrypoint diagnostics.
+- After Fly env/path changes, redeploy and confirm `/health` is stable and logs do not show repeated sqlite open failures.

--- a/n8drive/entrypoint.sh
+++ b/n8drive/entrypoint.sh
@@ -1,17 +1,49 @@
 #!/bin/sh
-set -e
+set -eu
 
 DATA_DIR="${CONTROLLED_DATA_DIR:-${DATA_DIR:-/app/data}}"
+APPROVAL_DB_PATH="${APPROVAL_DB_PATH:-$DATA_DIR/approvals.db}"
+PRR_DB_PATH="${PRR_DB_PATH:-$DATA_DIR/prr.db}"
+CONNECTOR_DB_PATH="${CONNECTOR_DB_PATH:-$DATA_DIR/connectors.db}"
+IDEMPOTENCY_DB_PATH="${IDEMPOTENCY_DB_PATH:-$DATA_DIR/idempotency.db}"
+RATE_LIMIT_DB_PATH="${RATE_LIMIT_DB_PATH:-$DATA_DIR/rate-limit.db}"
 
-# Ensure data directory exists and is writable
+# Ensure data directory exists
 mkdir -p "$DATA_DIR"
 
 # Change ownership to node user (uid:1000, gid:1000)
 # Volume mounts start as root-owned, we need to fix that
 chown -R node:node "$DATA_DIR" || true
 
-# Ensure directory is writable
-chmod -R u+w "$DATA_DIR" || true
+# Ensure directory is writable by owner/group
+chmod -R ug+rwX "$DATA_DIR" || true
+
+# Fail fast with clear diagnostics if the mounted directory is still not writable.
+if ! gosu node sh -c "test -w \"$DATA_DIR\""; then
+  echo "ERROR: data directory is not writable for node user: $DATA_DIR" >&2
+  ls -ld "$DATA_DIR" >&2 || true
+  exit 1
+fi
+
+ensure_db_file_writable() {
+  db_path="$1"
+  db_dir="$(dirname "$db_path")"
+  mkdir -p "$db_dir"
+  chown -R node:node "$db_dir" || true
+  chmod -R ug+rwX "$db_dir" || true
+
+  if ! gosu node sh -c "touch \"$db_path\""; then
+    echo "ERROR: sqlite path is not writable for node user: $db_path" >&2
+    ls -ld "$db_dir" >&2 || true
+    exit 1
+  fi
+}
+
+ensure_db_file_writable "$APPROVAL_DB_PATH"
+ensure_db_file_writable "$PRR_DB_PATH"
+ensure_db_file_writable "$CONNECTOR_DB_PATH"
+ensure_db_file_writable "$IDEMPOTENCY_DB_PATH"
+ensure_db_file_writable "$RATE_LIMIT_DB_PATH"
 
 # Drop privileges and run as node user
 exec gosu node "$@"

--- a/n8drive/fly.staging.toml
+++ b/n8drive/fly.staging.toml
@@ -31,4 +31,11 @@ primary_region = 'ewr'
 
 [[env]]
   CONTROLLED_DATA_DIR = '/app/data'
+  DATA_DIR = '/app/data'
+  LOGIC_COMMONS_DATA_DIR = '/app/data'
+  APPROVAL_DB_PATH = '/app/data/approvals.db'
+  PRR_DB_PATH = '/app/data/prr.db'
+  CONNECTOR_DB_PATH = '/app/data/connectors.db'
+  IDEMPOTENCY_DB_PATH = '/app/data/idempotency.db'
+  RATE_LIMIT_DB_PATH = '/app/data/rate-limit.db'
   PORT = '8080'


### PR DESCRIPTION
## Scope
Fix staging startup failure mode for SQLite `CANTOPEN` by making DB paths explicit and writable checks fail-fast:

- set deterministic staging env DB paths under `/app/data` in `n8drive/fly.staging.toml`
- harden `n8drive/entrypoint.sh` to verify writable data dir + DB files as `node`
- document staging troubleshooting note in `docs/DEVELOPER.md`

## Behavior change
- Startup now exits with explicit diagnostics if mounted data dir / db path is not writable by `node`.
- No production API contract changes.

## Validation
- `bash scripts/bootstrap.sh` ✅
- `source ~/.nvm/nvm.sh && nvm use 20 && cd n8drive/apps/puddlejumper && pnpm test -- --reporter=verbose` ✅

## Follow-up after merge
- Deploy staging and verify `/health` stable for one full deploy cycle.
- Confirm Fly logs show no repeated sqlite `CANTOPEN` errors.
