### PR TITLE
ops: prevent autostop during cold starts and increase health grace period

### DIFF
--- a/n8drive/fly.toml
+++ b/n8drive/fly.toml
@@ -1,3 +1,4 @@
+# fly.toml — launch-ready: prevent autostop during cold starts and give health check more grace
 app = "publiclogic-puddlejumper"
 primary_region = "ewr"
 
@@ -10,7 +11,9 @@ primary_region = "ewr"
 [http_service]
   internal_port = 3002
   force_https = true
-  auto_stop_machines = "stop"
+
+  # Prevent Fly from autostopping the machine during cold starts/launch
+  auto_stop_machines = "never"
   auto_start_machines = true
   min_machines_running = 1
   processes = ["app"]
@@ -19,7 +22,8 @@ primary_region = "ewr"
     type = "http"
     interval = "15s"
     timeout = "3s"
-    grace_period = "10s"
+    # Increased to allow Next.js standalone + native addons time to warm up
+    grace_period = "60s"
     method = "get"
     path = "/health"
 


### PR DESCRIPTION
## Changes
- Set `auto_stop_machines = 'never'` to prevent Fly from autostopping machines during cold starts
- Increase `grace_period` from 10s to 60s to allow Next.js standalone + native addons time to warm up
- Remove duplicate `apps/puddlejumper/fly.toml` to keep root config as canonical

## Why
Fly's autostop behavior can trigger during long initialization (Next.js + SQLite native modules), causing health check failures and machine cycling. This change stabilizes launch behavior.

## Testing
- CI must pass
- After merge: deploy to Fly and verify machine stays running with `fly machines list`
- Confirm health checks pass: `curl https://publiclogic-puddlejumper.fly.dev/health`