### PR TITLE
fix: use 'off' instead of 'never' for auto_stop_machines

### DIFF
--- a/n8drive/fly.toml
+++ b/n8drive/fly.toml
@@ -13,7 +13,7 @@ primary_region = "ewr"
   force_https = true
 
   # Prevent Fly from autostopping the machine during cold starts/launch
-  auto_stop_machines = "never"
+  auto_stop_machines = "off"
   auto_start_machines = true
   min_machines_running = 1
   processes = ["app"]


### PR DESCRIPTION
## Fix
Corrects invalid Fly.io config value from PR #74.

## Changes
- Change `auto_stop_machines = 'never'` → `'off'`
- Valid values are: `'off'`, `'stop'`, `'suspend'`

## Testing
- Config validation: `fly deploy` should not error
- Behavior: machines remain running (same intent as 'never')