### PR TITLE
fix: add API and auth rewrites for Vercel → Fly backend proxy

### DIFF
--- a/n8drive/web/next.config.ts
+++ b/n8drive/web/next.config.ts
@@ -5,6 +5,19 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   output: "standalone",
+  async rewrites() {
+    const backendUrl = process.env.BACKEND_URL || "https://publiclogic-puddlejumper.fly.dev";
+    return [
+      {
+        source: "/api/:path*",
+        destination: `${backendUrl}/api/:path*`,
+      },
+      {
+        source: "/auth/:path*",
+        destination: `${backendUrl}/auth/:path*`,
+      },
+    ];
+  },
   async redirects() {
     return [
       // Legacy backend route — redirect to the frontend home page


### PR DESCRIPTION
## Problem
Vercel deployment returns 404 for all `/api/*` and `/auth/*` requests because Next.js has no rewrites configured to proxy to the Fly.io backend. OAuth callbacks and API calls fail.

## Solution
Add rewrites in `next.config.ts`:
- `/api/:path*` → backend `/api/:path*`
- `/auth/:path*` → backend `/auth/:path*`

Backend URL controlled by `BACKEND_URL` env var (defaults to Fly production).

## Testing
After Vercel deploys this change:
```bash
curl -I https://www.publiclogic.org/api/health
# Expected: HTTP/2 200 (proxied to Fly)

curl -I https://www.publiclogic.org/api/auth/github/callback
# Expected: HTTP/2 400 (backend endpoint exists, missing code param)
```

## Related
- Completes OAuth redirect URI fix from PR #74-76
- Fly secrets already updated to use `www.publiclogic.org` callbacks
- After merge, OAuth flow should work end-to-end