### PR TITLE
fix: OAuth callback redirect to pj.publiclogic.org

### DIFF
--- a/n8drive/apps/puddlejumper/src/api/authCallback.ts
+++ b/n8drive/apps/puddlejumper/src/api/authCallback.ts
@@ -28,7 +28,7 @@ export default async function authCallback(req: Request, res: Response) {
     }
 
     setJwtCookieOnResponse(res, token, { maxAge: Number(process.env.JWT_MAX_AGE_SECONDS ?? 3600), sameSite: 'lax' });
-    res.redirect(process.env.PJ_UI_URL || '/');
+    res.redirect('https://pj.publiclogic.org/dashboard');
   } catch (err) {
     // eslint-disable-next-line no-console
     console.error('auth callback error', err);


### PR DESCRIPTION
## Problem
After OAuth authentication, users were redirected to www.publiclogic.org/dashboard (static marketing site) instead of pj.publiclogic.org/dashboard (Next.js app). This caused login loops.

## Solution
Update authCallback.ts line 31 to redirect to pj.publiclogic.org/dashboard.

## Testing
After merge + deploy:
1. Visit https://pj.publiclogic.org
2. Click 'Sign in with Google' or 'Sign in with Microsoft'
3. Complete OAuth flow
4. Should land on pj.publiclogic.org/dashboard (authenticated)