### PR TITLE
Tighten OAuth return targets and clarify admin UX

### DIFF
--- a/n8drive/apps/logic-commons/src/lib/oauth.ts
+++ b/n8drive/apps/logic-commons/src/lib/oauth.ts
@@ -19,8 +19,8 @@ export interface OAuthUserInfo {
 
 /** Structural interface for the OAuth state store (avoids private-field compatibility issues). */
 export interface IOAuthStateStore {
-  create(provider: string, codeVerifier?: string): string;
-  consume(state: string): { provider: string; codeVerifier?: string } | null;
+  create(provider: string, codeVerifier?: string, redirectTo?: string): string;
+  consume(state: string): { provider: string; codeVerifier?: string; redirectTo?: string } | null;
 }
 
 /** Declarative description of an OAuth 2.0 provider. */
@@ -109,12 +109,77 @@ export function createOAuthRoutes(
   const resolveFrontendUrl = () =>
     opts.frontendUrl || process.env.PJ_PUBLIC_URL || process.env.FRONTEND_URL || "https://pj.publiclogic.org";
 
+  function collectAllowedOrigins(): Set<string> {
+    const origins = new Set<string>();
+    const redirectUri = process.env[provider.redirectUriEnvVar] || provider.defaultRedirectUri;
+    const candidates = [
+      resolveFrontendUrl(),
+      opts.frontendUrl,
+      process.env.PJ_PUBLIC_URL,
+      process.env.FRONTEND_URL,
+      process.env.LOGIC_COMMONS_URL,
+      redirectUri,
+    ];
+    for (const candidate of candidates) {
+      if (!candidate) continue;
+      try {
+        origins.add(new URL(candidate).origin);
+      } catch {
+        // Ignore malformed env overrides instead of crashing auth.
+      }
+    }
+    return origins;
+  }
+
+  function resolveDefaultReturnOrigin(): string {
+    const redirectUri = process.env[provider.redirectUriEnvVar] || provider.defaultRedirectUri;
+    try {
+      return new URL(redirectUri).origin;
+    } catch {
+      return resolveFrontendUrl();
+    }
+  }
+
+  function normalizeRedirectTarget(rawTarget: string | undefined): string | null {
+    const target = rawTarget?.trim();
+    if (!target) return null;
+
+    const fallbackOrigin = resolveDefaultReturnOrigin();
+    if (target.startsWith("/") && !target.startsWith("//")) {
+      try {
+        return new URL(target, fallbackOrigin).toString();
+      } catch {
+        return null;
+      }
+    }
+
+    try {
+      const url = new URL(target);
+      if (!["http:", "https:"].includes(url.protocol)) return null;
+      return collectAllowedOrigins().has(url.origin) ? url.toString() : null;
+    } catch {
+      return null;
+    }
+  }
+
+  function withRedirectParams(target: string, params: Record<string, string>): string {
+    const url = new URL(target);
+    for (const [key, value] of Object.entries(params)) {
+      url.searchParams.set(key, value);
+    }
+    return url.toString();
+  }
+
   // ── Login redirect ────────────────────────────────────────────────────────
-  router.get(`/auth/${provider.name}/login`, (_req, res) => {
+  router.get(`/auth/${provider.name}/login`, (req, res) => {
     const clientId = process.env[provider.clientIdEnvVar];
     if (!clientId) {
       return res.status(500).json({ error: `${provider.name} OAuth not configured` });
     }
+
+    const redirectTo = normalizeRedirectTarget(
+      typeof req.query.redirect_to === "string" ? req.query.redirect_to : undefined,
+    );
 
     // Generate PKCE code_verifier and code_challenge for enhanced security
     const codeVerifier = crypto.randomBytes(32).toString("base64url");
@@ -123,7 +188,7 @@ export function createOAuthRoutes(
       .update(codeVerifier)
       .digest("base64url");
 
-    const state = opts.oauthStateStore.create(provider.name, codeVerifier);
+    const state = opts.oauthStateStore.create(provider.name, codeVerifier, redirectTo || undefined);
     const redirectUri =
       process.env[provider.redirectUriEnvVar] || provider.defaultRedirectUri;
 
@@ -286,7 +351,11 @@ export function createOAuthRoutes(
       });
 
       // Redirect to frontend (cookie carries the session — no token in URL)
-      return res.redirect(`${resolveFrontendUrl()}?auth=success&connected=${encodeURIComponent(provider.name)}`);
+      const finalRedirect = stateResult.redirectTo || resolveFrontendUrl();
+      return res.redirect(withRedirectParams(finalRedirect, {
+        auth: "success",
+        connected: provider.name,
+      }));
     } catch (err: any) {
       // eslint-disable-next-line no-console
       console.error(`${provider.name} OAuth callback error:`, err?.message);
@@ -297,7 +366,10 @@ export function createOAuthRoutes(
       });
       const isAccessDenied = err?.statusCode === 403
       const errorParam = isAccessDenied ? 'access_denied' : 'authentication_failed'
-      return res.redirect(`${resolveFrontendUrl()}/?oauth_error=${errorParam}`);
+      const finalRedirect = stateResult.redirectTo || resolveFrontendUrl();
+      return res.redirect(withRedirectParams(finalRedirect, {
+        oauth_error: errorParam,
+      }));
     }
   });
 

--- a/n8drive/apps/logic-commons/src/lib/state-store.ts
+++ b/n8drive/apps/logic-commons/src/lib/state-store.ts
@@ -25,7 +25,8 @@ export class OAuthStateStore {
         created_at    INTEGER NOT NULL,
         expires_at    INTEGER NOT NULL,
         used          INTEGER NOT NULL DEFAULT 0,
-        code_verifier TEXT
+        code_verifier TEXT,
+        redirect_to   TEXT
       )
     `);
 
@@ -40,20 +41,24 @@ export class OAuthStateStore {
       this.db.exec("ALTER TABLE oauth_state ADD COLUMN code_verifier TEXT");
     }
 
+    if (!cols.some((c) => c.name === "redirect_to")) {
+      this.db.exec("ALTER TABLE oauth_state ADD COLUMN redirect_to TEXT");
+    }
+
     // Auto-prune expired rows
     this.pruneTimer = setInterval(() => this.prune(), PRUNE_INTERVAL_MS);
     this.pruneTimer.unref?.();
   }
 
   /** Create a new state token for the given provider, optionally with PKCE code_verifier. */
-  create(provider: string, codeVerifier?: string): string {
+  create(provider: string, codeVerifier?: string, redirectTo?: string): string {
     const state = crypto.randomUUID();
     const now = Date.now();
     this.db
       .prepare(
-        "INSERT INTO oauth_state (state, provider, created_at, expires_at, code_verifier) VALUES (?, ?, ?, ?, ?)",
+        "INSERT INTO oauth_state (state, provider, created_at, expires_at, code_verifier, redirect_to) VALUES (?, ?, ?, ?, ?, ?)",
       )
-      .run(state, provider, now, now + STATE_TTL_MS, codeVerifier || null);
+      .run(state, provider, now, now + STATE_TTL_MS, codeVerifier || null, redirectTo || null);
     return state;
   }
 
@@ -63,7 +68,7 @@ export class OAuthStateStore {
    * Returns an object with provider and code_verifier (if PKCE was used),
    * or `null` if it doesn't exist, was already consumed, or has expired.
    */
-  consume(state: string): { provider: string; codeVerifier?: string } | null {
+  consume(state: string): { provider: string; codeVerifier?: string; redirectTo?: string } | null {
     const now = Date.now();
 
     // Atomic single-use: only marks as used if not already used and not expired
@@ -75,14 +80,15 @@ export class OAuthStateStore {
 
     // Fetch the provider and code_verifier after successful CAS
     const row = this.db
-      .prepare("SELECT provider, code_verifier FROM oauth_state WHERE state = ?")
-      .get(state) as { provider: string; code_verifier: string | null } | undefined;
+      .prepare("SELECT provider, code_verifier, redirect_to FROM oauth_state WHERE state = ?")
+      .get(state) as { provider: string; code_verifier: string | null; redirect_to: string | null } | undefined;
 
     if (!row) return null;
 
     return {
       provider: row.provider,
       codeVerifier: row.code_verifier || undefined,
+      redirectTo: row.redirect_to || undefined,
     };
   }
 

--- a/n8drive/apps/logic-commons/test/oauth-factory.test.ts
+++ b/n8drive/apps/logic-commons/test/oauth-factory.test.ts
@@ -114,6 +114,39 @@ describe("GET /api/auth/:provider/login", () => {
     expect(location.searchParams.get("state")).toBeTruthy();
   });
 
+  it("stores an allowed redirect override from the login request", async () => {
+    const app = makeApp();
+    const res = await request(app)
+      .get("/api/auth/testprov/login")
+      .query({ redirect_to: "http://localhost:3000/casespaces/demo" })
+      .redirects(0);
+
+    const state = new URL(res.headers.location).searchParams.get("state");
+    expect(state).toBeTruthy();
+    expect(stateStore.consume(state!)).toEqual({
+      provider: "testprov",
+      codeVerifier: expect.any(String),
+      redirectTo: "http://localhost:3000/casespaces/demo",
+    });
+  });
+
+  it("rejects redirect overrides for untrusted origins even when the referer is attacker-controlled", async () => {
+    const app = makeApp();
+    const res = await request(app)
+      .get("/api/auth/testprov/login")
+      .set("referer", "https://evil.example/launch")
+      .query({ redirect_to: "https://evil.example/callback" })
+      .redirects(0);
+
+    const state = new URL(res.headers.location).searchParams.get("state");
+    expect(state).toBeTruthy();
+    expect(stateStore.consume(state!)).toEqual({
+      provider: "testprov",
+      codeVerifier: expect.any(String),
+      redirectTo: undefined,
+    });
+  });
+
   it("sets a CSRF state cookie", async () => {
     const app = makeApp();
     const res = await request(app).get("/api/auth/testprov/login").redirects(0);
@@ -217,6 +250,36 @@ describe("GET /api/auth/:provider/callback", () => {
       const cookies = Array.isArray(setCookieHeader) ? setCookieHeader : setCookieHeader ? [setCookieHeader] : [];
       expect(cookies.some((c: string) => c.startsWith("jwt="))).toBe(true);
       expect(cookies.some((c: string) => c.startsWith("pj_refresh="))).toBe(true);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("redirects back to the stored redirect override after callback success", async () => {
+    const app = makeApp();
+    const loginRes = await request(app)
+      .get("/api/auth/testprov/login")
+      .query({ redirect_to: "http://localhost:3000/casespaces/demo?tab=modules" })
+      .redirects(0);
+    const validState = new URL(loginRes.headers.location).searchParams.get("state")!;
+
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ access_token: "mock-access-tok" }),
+    });
+
+    try {
+      const res = await request(app)
+        .get(`/api/auth/testprov/callback?code=good-code&state=${validState}`)
+        .redirects(0);
+
+      expect(res.status).toBe(302);
+      const redirectUrl = new URL(res.headers.location);
+      expect(redirectUrl.origin + redirectUrl.pathname).toBe("http://localhost:3000/casespaces/demo");
+      expect(redirectUrl.searchParams.get("tab")).toBe("modules");
+      expect(redirectUrl.searchParams.get("auth")).toBe("success");
+      expect(redirectUrl.searchParams.get("connected")).toBe("testprov");
     } finally {
       globalThis.fetch = originalFetch;
     }

--- a/n8drive/apps/logic-commons/test/state-store.test.ts
+++ b/n8drive/apps/logic-commons/test/state-store.test.ts
@@ -26,6 +26,15 @@ describe("OAuthStateStore", () => {
     expect(result?.provider).toBe("github");
   });
 
+  it("persists redirect targets alongside the state token", () => {
+    const state = store.create("github", "pkce-verifier", "https://pj.publiclogic.org/pj/admin");
+    expect(store.consume(state)).toEqual({
+      provider: "github",
+      codeVerifier: "pkce-verifier",
+      redirectTo: "https://pj.publiclogic.org/pj/admin",
+    });
+  });
+
   it("returns null when consuming a non-existent state", () => {
     expect(store.consume("nonexistent")).toBeNull();
   });

--- a/n8drive/apps/puddlejumper/public/admin.html
+++ b/n8drive/apps/puddlejumper/public/admin.html
@@ -4,7 +4,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>PuddleJumper — Control Plane</title>
+<title>PuddleJumper — Workspace Operations</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&family=IBM+Plex+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
 <link rel="stylesheet" href="/styles/pj-admin.css">
@@ -16,10 +16,11 @@
   <div class="header-brand">
     <a class="logo" href="/">Puddle<span>Jumper</span></a>
     <div class="sep"></div>
-    <div class="subtitle">Control Plane</div>
+    <div class="subtitle">Workspace Operations</div>
     <div class="ws-chip" id="ws-chip"></div>
   </div>
   <div class="header-right">
+    <a class="header-btn" id="logicos-link" href="https://os.publiclogic.org">LogicOS</a>
     <div class="auto-ref-badge" id="auto-ref"><div class="dot"></div>Auto</div>
     <a class="header-btn" href="/pj/guide">Guide</a>
     <button class="header-btn" onclick="refresh()" id="refresh-btn">↻ Refresh</button>
@@ -33,17 +34,24 @@
 
 <!-- Tabs -->
 <div class="tabs">
-  <button class="tab active" data-tab="queue" onclick="switchTab('queue')">Vault Doc Management <span style="display:inline-block;font-size:9px;font-weight:700;background:#f59e0b;color:#000;padding:1px 5px;border-radius:3px;vertical-align:middle;letter-spacing:0.05em;">DEV</span></button>
+  <button class="tab active" data-tab="queue" onclick="switchTab('queue')">Approvals &amp; Dispatch</button>
   <button class="tab" data-tab="chains" onclick="switchTab('chains')">Chain Templates</button>
   <button class="tab" data-tab="dashboard" onclick="switchTab('dashboard')">Dashboard</button>
   <button class="tab" data-tab="prr" onclick="switchTab('prr')">Records</button>
-  <button class="tab" data-tab="members" onclick="switchTab('members')">Members</button>
+  <button class="tab" data-tab="members" onclick="switchTab('members')">Members &amp; Plan</button>
+</div>
+
+<div class="viewer-banner" style="display:block;background:#0b1f1a;border-top:1px solid #16352b;border-bottom:1px solid #16352b;">
+  <span>
+    PJ is the backend operator surface for <strong>Docs, Forms, Vault, Flows, Records, and routing</strong>.
+    Use this page for approvals, chain templates, members, and workspace limits — not for authoring document or form templates.
+  </span>
 </div>
 
 <!-- Auth Gate -->
 <div id="auth-gate">
   <h2>// sign in required</h2>
-  <p>Authentication required to access the control plane.</p>
+  <p>Authentication required to access workspace operations.</p>
   <div class="sign-in-card">
     <a href="/api/auth/github/login" class="oauth-btn oauth-github">
       <svg width="18" height="18" viewBox="0 0 16 16" fill="white"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
@@ -64,7 +72,7 @@
 <!-- ── APPROVAL QUEUE TAB ─────────────────────────────── -->
 <div class="main" id="tab-queue" style="display:none">
   <div class="tbl-header">
-    <h2>Vault Governed Document Management</h2>
+    <h2>Approvals &amp; Dispatch Queue</h2>
     <div class="tbl-actions">
       <select class="filter-select" id="status-filter" onchange="currentPage=0;loadApprovals()">
         <option value="pending">Pending</option>
@@ -76,6 +84,9 @@
         <option value="">All</option>
       </select>
     </div>
+  </div>
+  <div class="warn-notice" style="margin-bottom:16px">
+    Review governed actions before they dispatch. This queue is the backend execution surface behind LogicOS workspaces.
   </div>
   <div class="tbl-wrap">
     <table>
@@ -107,13 +118,16 @@
 <!-- ── CHAIN TEMPLATES TAB ──────────────────────────────── -->
 <div class="main" id="tab-chains" style="display:none">
   <div class="tbl-header">
-    <h2>Chain Templates</h2>
-    <button class="btn btn-primary btn-lg" id="btn-new-template" onclick="toggleTemplateForm()">+ New Template</button>
+    <h2>Approval Chain Templates</h2>
+    <button class="btn btn-primary btn-lg" id="btn-new-template" onclick="toggleTemplateForm()">+ New Chain</button>
+  </div>
+  <div class="warn-notice" style="margin-bottom:16px">
+    These templates define approval routes for governed actions. They do not replace Docs templates, Forms templates, or Vault document shells.
   </div>
 
   <!-- Create/Edit form -->
   <div class="form-panel" id="template-form">
-    <div class="form-title" id="template-form-title">Create Template</div>
+    <div class="form-title" id="template-form-title">Create Approval Chain</div>
     <input type="hidden" id="template-edit-id">
     <div class="form-row">
       <label>Name</label>
@@ -134,9 +148,9 @@
     </div>
   </div>
 
-  <div id="templates-loading" class="empty" style="display:none">Loading templates…</div>
+  <div id="templates-loading" class="empty" style="display:none">Loading chain templates…</div>
   <div class="template-grid" id="templates-grid"></div>
-  <div id="templates-empty" class="empty" style="display:none">No templates yet — create one above</div>
+  <div id="templates-empty" class="empty" style="display:none">No chain templates yet — create one above</div>
 </div>
 
 <!-- ── DASHBOARD TAB ────────────────────────────────────── -->
@@ -226,6 +240,9 @@
       <div class="empty mono dim" style="padding:12px 0">Loading usage…</div>
     </div>
   </div>
+  <div class="warn-notice" style="margin-bottom:16px">
+    Plan limits shown here cover <strong>chain templates, approvals, and members</strong>. Docs, Forms, and Vault content are managed in LogicOS workspaces.
+  </div>
 
   <div class="tbl-header">
     <h2>Members</h2>
@@ -239,8 +256,8 @@
     <div class="form-row">
       <label>Role</label>
       <select id="invite-role">
-        <option value="admin">Admin — manage templates & invites</option>
-        <option value="member" selected>Member — create & decide approvals</option>
+        <option value="admin">Admin — manage chain templates, members, and invites</option>
+        <option value="member" selected>Member — submit work and decide approvals</option>
         <option value="viewer">Viewer — read-only</option>
       </select>
     </div>
@@ -294,23 +311,26 @@
 <div id="upgrade-modal" onclick="closeUpgradeModal(event)">
   <div class="modal-card" onclick="event.stopPropagation()">
     <div class="modal-head">
-      <h3>Upgrade Workspace</h3>
+      <h3>Workspace Plan &amp; Limits</h3>
       <button class="panel-close" onclick="closeUpgradeModal()">✕</button>
     </div>
     <div style="margin-bottom:16px">
       Current plan: <span id="current-plan-badge" class="plan-badge plan-free">FREE</span>
     </div>
+    <div class="warn-notice" style="margin-bottom:16px">
+      This page controls workspace entitlements only. Docs, Forms, and Vault own their own templates; the quota here refers to <strong>approval chain templates</strong> in PJ operations.
+    </div>
     <label class="plan-option">
       <input type="radio" name="plan-pick" value="free" checked>
-      <div><div class="po-name">Free</div><div class="po-desc">3 templates · 50 approvals/mo · 1 member</div></div>
+      <div><div class="po-name">Free</div><div class="po-desc">3 chain templates · 50 approvals/mo · 1 member</div></div>
     </label>
     <label class="plan-option">
       <input type="radio" name="plan-pick" value="pro">
-      <div><div class="po-name" style="color:var(--accent)">Pro</div><div class="po-desc">Unlimited templates, approvals, and members</div></div>
+      <div><div class="po-name" style="color:var(--accent)">Pro</div><div class="po-desc">Unlimited chain templates, approvals, and members</div></div>
     </label>
-    <div class="warn-notice">⚠ Manual admin operation — billing not yet implemented.</div>
+    <div class="warn-notice">⚠ Manual admin operation — billing is not self-serve yet.</div>
     <div class="form-btns">
-      <button class="btn btn-primary" onclick="submitPlanChange()">Confirm</button>
+      <button class="btn btn-primary" onclick="submitPlanChange()">Save plan</button>
       <button class="btn btn-secondary" onclick="closeUpgradeModal()">Cancel</button>
     </div>
   </div>
@@ -333,6 +353,20 @@ const HASH_TAB = Object.fromEntries(Object.entries(TAB_HASH).map(([k,v])=>[v,k])
 
 // ── Helpers ───────────────────────────────────────────────
 function getCookie(n){const m=document.cookie.match(new RegExp("(?:^|; )"+n+"=([^;]*)"));return m?decodeURIComponent(m[1]):null}
+
+function logicOsUrl(){
+  return window.location.hostname === 'localhost' ? 'http://localhost:3000' : 'https://os.publiclogic.org';
+}
+
+function setOperatorOAuthReturnLinks(){
+  const redirectTo = `${window.location.origin}/pj/admin`;
+  document.querySelectorAll('a[href^="/api/auth/"]').forEach((anchor)=>{
+    if(!(anchor instanceof HTMLAnchorElement)) return;
+    const url = new URL(anchor.getAttribute('href') || '', window.location.origin);
+    url.searchParams.set('redirect_to', redirectTo);
+    anchor.setAttribute('href', `${url.pathname}${url.search}`);
+  });
+}
 
 function authHeaders(){
   const h={"Content-Type":"application/json"};
@@ -414,6 +448,9 @@ function switchTab(tab){
   if(tab==='prr') loadPRRQueue();
   if(tab==='members'){loadMembers();loadUsage()}
 }
+
+document.getElementById('logicos-link')?.setAttribute('href', logicOsUrl());
+setOperatorOAuthReturnLinks();
 
 // ── Approval Queue ────────────────────────────────────────
 async function loadApprovals(){
@@ -1027,6 +1064,7 @@ function renderUsage(usage){
   badge.className=`plan-badge plan-${usage.plan}`;
   document.getElementById('upgrade-btn').style.display=usage.plan==='free'?'block':'none';
   const metrics=document.getElementById('usage-metrics');
+  const labelMap={templates:'Chain templates',approvals:'Approvals',members:'Members'};
   metrics.innerHTML=['templates','approvals','members'].map(k=>{
     const cur=usage.usage[k],lim=usage.limits[k];
     const pct=lim>0?Math.min((cur/lim)*100,100):0;
@@ -1034,7 +1072,7 @@ function renderUsage(usage){
     const barCls=atLim?'at-limit':nearLim?'near':'';
     const chip=atLim?`<span class="limit-chip err">LIMIT</span>`:nearLim?`<span class="limit-chip warn">NEAR</span>`:'';
     return`<div class="usage-item">
-      <div class="usage-lbl"><strong>${k.charAt(0).toUpperCase()+k.slice(1)}</strong><div>${chip}<span class="usage-count-text">${cur} / ${lim>=999999?'∞':lim}</span></div></div>
+      <div class="usage-lbl"><strong>${labelMap[k] ?? k.charAt(0).toUpperCase()+k.slice(1)}</strong><div>${chip}<span class="usage-count-text">${cur} / ${lim>=999999?'∞':lim}</span></div></div>
       <div class="usage-track"><div class="usage-bar ${barCls}" style="width:${pct}%"></div></div>
     </div>`;
   }).join('');

--- a/n8drive/apps/puddlejumper/public/scripts/main.js
+++ b/n8drive/apps/puddlejumper/public/scripts/main.js
@@ -22,6 +22,16 @@
     return document.getElementById("authState");
   }
 
+  function decorateOAuthLinks(returnPath) {
+    var target = window.location.origin + returnPath;
+    document.querySelectorAll('a[href^="/api/auth/"]').forEach(function (anchor) {
+      if (!(anchor instanceof HTMLAnchorElement)) return;
+      var url = new URL(anchor.getAttribute("href"), window.location.origin);
+      url.searchParams.set("redirect_to", target);
+      anchor.setAttribute("href", url.pathname + url.search);
+    });
+  }
+
   function setAuthState(state, text) {
     var pill = getStatusPill();
     if (!pill) return;
@@ -185,6 +195,8 @@
         }
       });
     }
+
+    decorateOAuthLinks("/pj/admin");
 
     document.addEventListener("keydown", function (event) {
       if (event.key === "Escape" && isGateOpen()) {

--- a/n8drive/apps/puddlejumper/public/scripts/pj-signin.js
+++ b/n8drive/apps/puddlejumper/public/scripts/pj-signin.js
@@ -17,6 +17,13 @@
   var successEl = document.getElementById("formSuccess");
   var toastEl = document.getElementById("toast");
 
+  document.querySelectorAll('a[href^="/api/auth/"]').forEach(function (anchor) {
+    if (!(anchor instanceof HTMLAnchorElement)) return;
+    var url = new URL(anchor.getAttribute("href"), window.location.origin);
+    url.searchParams.set("redirect_to", window.location.origin + "/pj/admin");
+    anchor.setAttribute("href", url.pathname + url.search);
+  });
+
   /* ── Helpers ─────────────────────────────────────────────── */
   function setBusy(busy) {
     signinBtn.setAttribute("aria-busy", busy ? "true" : "false");

--- a/n8drive/apps/puddlejumper/src/api/server.ts
+++ b/n8drive/apps/puddlejumper/src/api/server.ts
@@ -749,8 +749,7 @@ export function createApp(nodeEnv: string = process.env.NODE_ENV ?? "development
     const allowedDomains = (process.env.ALLOWED_DOMAINS ?? '')
       .split(',').map(s => s.trim().toLowerCase()).filter(Boolean)
     if (allowedEmails.length > 0 || allowedDomains.length > 0) {
-      const dataDir = process.env.DATA_DIR || "./data";
-      const localUser = findLocalUserById(dataDir, auth.sub);
+      const localUser = findLocalUserById(CONTROLLED_DATA_DIR, auth.sub);
       if (localUser) {
         res.json({
           sub: auth.sub,

--- a/n8drive/apps/puddlejumper/src/lib/ids.js
+++ b/n8drive/apps/puddlejumper/src/lib/ids.js
@@ -1,0 +1,86 @@
+// ids.js
+// ============================================================================
+// LogicOS V1 Spine — ID generator
+//
+// Path:    /src/lib/ids.js
+// Used by: records routes, intake route, any creation path
+//
+// Generates IDs of the form AREA-YYYY-NNN (zero-padded to 3 digits).
+// Sequence is per (area, year) and resets on January 1.
+// Increment is atomic via a SQLite transaction with conflict-resolved upsert.
+// Throws on unknown area code — never silently defaults.
+//
+// Concurrency: better-sqlite3 with WAL mode serializes writes per database
+// connection, so the transaction below is sufficient for V1's scale.
+// If we ever shard the writer, this needs to become a SELECT FOR UPDATE
+// equivalent (advisory lock via INSERT OR FAIL on a lock row).
+// ============================================================================
+
+'use strict';
+
+const VALID_AREAS = Object.freeze(['PL', 'PI', 'CAM', 'LIFE', 'LAB']);
+
+class UnknownAreaError extends Error {
+  constructor(area) {
+    super(`Unknown area code: ${JSON.stringify(area)}. Valid areas: ${VALID_AREAS.join(', ')}`);
+    this.name = 'UnknownAreaError';
+    this.code = 'unknown_area';
+  }
+}
+
+function isValidArea(area) {
+  return typeof area === 'string' && VALID_AREAS.includes(area);
+}
+
+/**
+ * Build an ID generator bound to a database connection.
+ * @param {import('better-sqlite3').Database} db
+ * @returns {{ next: (area: string) => string, validAreas: () => string[] }}
+ */
+function createIdGenerator(db) {
+  // Prepared statements bound to this db connection.
+  const upsert = db.prepare(`
+    INSERT INTO id_sequence (area, year, seq) VALUES (?, ?, 1)
+    ON CONFLICT(area, year) DO UPDATE SET seq = seq + 1
+    RETURNING seq
+  `);
+
+  // Wrap upsert in a transaction so the read-modify-write is atomic
+  // even under contention. better-sqlite3 transactions are synchronous
+  // and serialize automatically on a single connection.
+  const incrementSeq = db.transaction((area, year) => {
+    const row = upsert.get(area, year);
+    if (!row || typeof row.seq !== 'number') {
+      // Should be unreachable; if it happens, fail loud rather than fake an ID.
+      throw new Error(`id_sequence upsert returned no row for ${area}-${year}`);
+    }
+    return row.seq;
+  });
+
+  /**
+   * Get the next ID for the given area, in the current UTC year.
+   * @param {string} area
+   * @returns {string} ID like "CAM-2026-001"
+   */
+  function next(area) {
+    if (!isValidArea(area)) {
+      throw new UnknownAreaError(area);
+    }
+    const year = new Date().getUTCFullYear();
+    const seq = incrementSeq(area, year);
+    const padded = String(seq).padStart(3, '0');
+    return `${area}-${year}-${padded}`;
+  }
+
+  return {
+    next,
+    validAreas: () => [...VALID_AREAS]
+  };
+}
+
+module.exports = {
+  createIdGenerator,
+  UnknownAreaError,
+  VALID_AREAS,
+  isValidArea
+};

--- a/n8drive/apps/puddlejumper/src/lib/router.js
+++ b/n8drive/apps/puddlejumper/src/lib/router.js
@@ -1,0 +1,112 @@
+// router.js
+// ============================================================================
+// LogicOS V1 Spine — area router
+//
+// Path:    /src/lib/router.js
+// Used by: records routes, intake route, anywhere a record gets created
+//
+// PURE FUNCTION. Takes an area code (and an optional override flag for PI),
+// returns a routing decision. Does not touch the database, does not call
+// connectors, does not produce side effects of any kind. This is enforced
+// by keeping it dependency-free.
+//
+// V1 mappings:
+//   CAM   -> google   (folder)   — WIRED in V1
+//   LIFE  -> google   (folder)   — WIRED in V1
+//   PL    -> m365     (folder)   — connector not implemented; will queue
+//   PI    -> m365     (folder)   — connector not implemented; will queue
+//                                  homeOverride: 'google' allowed for PI only
+//   LAB   -> github   (repo)     — connector not implemented; will queue
+//
+// When PI gets a Google override (homeOverride === 'google'), it will need
+// its own parent folder env var. PI currently has no parent folder
+// configured. Add GOOGLE_DRIVE_PARENT_PI when PI Google routing is enabled.
+// (Not in V1.)
+// ============================================================================
+
+'use strict';
+
+const { isValidArea, UnknownAreaError } = require('./ids');
+
+class InvalidOverrideError extends Error {
+  constructor(area, override) {
+    super(
+      `Home override ${JSON.stringify(override)} not allowed for area ${JSON.stringify(area)}. ` +
+      `Override is only valid for PI.`
+    );
+    this.name = 'InvalidOverrideError';
+    this.code = 'invalid_override';
+  }
+}
+
+const ROUTING_TABLE = Object.freeze({
+  PL:   { home: 'm365',   destination: 'folder' },
+  PI:   { home: 'm365',   destination: 'folder' },
+  CAM:  { home: 'google', destination: 'folder' },
+  LIFE: { home: 'google', destination: 'folder' },
+  LAB:  { home: 'github', destination: 'repo'   }
+});
+
+const VALID_OVERRIDES = Object.freeze({
+  PI: Object.freeze(['google'])
+});
+
+const CONNECTOR_IMPLEMENTED = Object.freeze({
+  google: true,
+  m365:   false,
+  github: false
+});
+
+/**
+ * Decide where a record of a given area belongs.
+ *
+ * @param {string} area               Area code: PL, PI, CAM, LIFE, LAB
+ * @param {object} [opts]
+ * @param {string} [opts.homeOverride] Optional home override. PI only, value 'google'.
+ * @returns {{
+ *   home: 'google' | 'm365' | 'github',
+ *   destination: 'folder' | 'doc' | 'issue' | 'repo',
+ *   connectorImplemented: boolean,
+ *   initialConnectorState: 'queued' | 'not_started'
+ * }}
+ *
+ * The returned `initialConnectorState` is the truthful starting state for
+ * the record's connector_state column:
+ *   - 'queued' when a connector exists for the chosen home
+ *   - 'not_started' when the connector is not yet implemented
+ *
+ * Never returns a fake 'completed' or hidden error state. The router's
+ * job is to decide; running the connector is someone else's job.
+ */
+function route(area, opts = {}) {
+  if (!isValidArea(area)) {
+    throw new UnknownAreaError(area);
+  }
+
+  const { homeOverride } = opts;
+  let decision = ROUTING_TABLE[area];
+
+  if (homeOverride !== undefined) {
+    const allowed = VALID_OVERRIDES[area];
+    if (!allowed || !allowed.includes(homeOverride)) {
+      throw new InvalidOverrideError(area, homeOverride);
+    }
+    decision = { home: homeOverride, destination: 'folder' };
+  }
+
+  const connectorImplemented = CONNECTOR_IMPLEMENTED[decision.home] === true;
+
+  return {
+    home: decision.home,
+    destination: decision.destination,
+    connectorImplemented,
+    initialConnectorState: connectorImplemented ? 'queued' : 'not_started'
+  };
+}
+
+module.exports = {
+  route,
+  InvalidOverrideError,
+  ROUTING_TABLE,
+  CONNECTOR_IMPLEMENTED
+};

--- a/n8drive/apps/puddlejumper/src/migrations/001_records.sql
+++ b/n8drive/apps/puddlejumper/src/migrations/001_records.sql
@@ -1,0 +1,82 @@
+-- 001_records.sql
+-- ============================================================================
+-- LogicOS V1 Spine — records table
+--
+-- This is the canonical table for every captured record in the system.
+-- Created at:    pj.publiclogic.org (PuddleJumper backend)
+-- Path:          /src/migrations/001_records.sql
+--
+-- Notes:
+--   - `home` is set once at creation by the router and is never changed.
+--     Existing records reflect the routing rule that was in effect at their
+--     creation time. This preserves audit-trail truth. The application layer
+--     enforces this via PATCH field whitelist; a hardening trigger is
+--     deferred to V2.
+--   - `collaborators` is a JSON array of user_ids, validated at the DB level.
+--     When PI volume grows, migrate to a join table. Not before.
+--   - `lastError` is JSON with shape {code, message, retryable}. Strict
+--     structure is enforced in the application layer, not here.
+--   - `connectorState` and `status` are intentionally distinct enums.
+--     status = your judgment about the work.
+--     connectorState = the system's report of what it actually did.
+--     They never collapse into each other.
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS records (
+  id              TEXT PRIMARY KEY,                -- AREA-YEAR-NNN format
+  title           TEXT NOT NULL,
+  area            TEXT NOT NULL CHECK(area IN ('PL', 'PI', 'CAM', 'LIFE', 'LAB')),
+  status          TEXT NOT NULL DEFAULT 'idea'
+                    CHECK(status IN ('idea', 'active', 'waiting', 'done', 'archived')),
+
+  owner           TEXT NOT NULL,                   -- user_id (UUID)
+  collaborators   TEXT NOT NULL DEFAULT '[]'
+                    CHECK(json_valid(collaborators)),
+
+  home            TEXT NOT NULL CHECK(home IN ('google', 'm365', 'github')),
+  destination     TEXT,                            -- folder | doc | issue | repo
+
+  primary_link    TEXT,
+  google_link     TEXT,
+  m365_link       TEXT,
+  github_link     TEXT,
+
+  next_action     TEXT,
+  due_date        TEXT,                            -- ISO 8601 date
+  notes           TEXT,
+  source          TEXT CHECK(source IN ('shortcut', 'web', 'email', 'manual') OR source IS NULL),
+
+  routing_state   TEXT NOT NULL DEFAULT 'pending'
+                    CHECK(routing_state IN ('pending', 'routed', 'failed')),
+  connector_state TEXT NOT NULL DEFAULT 'not_started'
+                    CHECK(connector_state IN ('not_started', 'queued', 'running', 'completed', 'failed')),
+  last_error      TEXT CHECK(last_error IS NULL OR json_valid(last_error)),
+
+  created_at      TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+  updated_at      TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+);
+
+-- Sequence table backing the ID generator. One row per (area, year).
+-- The ID generator increments `seq` atomically inside a transaction.
+CREATE TABLE IF NOT EXISTS id_sequence (
+  area      TEXT NOT NULL,
+  year      INTEGER NOT NULL,
+  seq       INTEGER NOT NULL DEFAULT 0,
+  PRIMARY KEY (area, year)
+);
+
+-- Indexes for common query paths.
+CREATE INDEX IF NOT EXISTS idx_records_area_year     ON records(area, created_at);
+CREATE INDEX IF NOT EXISTS idx_records_status        ON records(status);
+CREATE INDEX IF NOT EXISTS idx_records_owner         ON records(owner);
+CREATE INDEX IF NOT EXISTS idx_records_connector     ON records(connector_state)
+  WHERE connector_state IN ('queued', 'running', 'failed');
+
+-- Touch updated_at on every UPDATE.
+CREATE TRIGGER IF NOT EXISTS records_updated_at
+  AFTER UPDATE ON records
+  FOR EACH ROW
+  WHEN OLD.updated_at = NEW.updated_at
+BEGIN
+  UPDATE records SET updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now') WHERE id = NEW.id;
+END;

--- a/n8drive/apps/puddlejumper/test/oauth-redirect.test.ts
+++ b/n8drive/apps/puddlejumper/test/oauth-redirect.test.ts
@@ -150,6 +150,35 @@ describe("GitHub OAuth redirect flow", () => {
     expect(refreshCookie).toContain("HttpOnly");
   });
 
+  it("returns to the requested PJ operator route after OAuth login", async () => {
+    const app = await createTestApp();
+
+    const loginRes = await request(app)
+      .get("/api/auth/github/login")
+      .set("referer", "http://localhost:3002/pj/signin")
+      .query({ redirect_to: "http://localhost:3002/pj/admin" });
+    const stateValue = new URL(loginRes.headers.location).searchParams.get("state")!;
+
+    global.fetch = vi.fn().mockImplementation(async (url: string) => {
+      if (String(url).includes("login/oauth/access_token")) {
+        return { ok: true, json: async () => ({ access_token: "gho_mock" }) };
+      }
+      if (String(url).includes("api.github.com/user")) {
+        return { ok: true, json: async () => ({ id: 12345, login: "octocat", name: "Octocat", email: "octocat@github.com" }) };
+      }
+      throw new Error(`Unexpected fetch: ${url}`);
+    });
+
+    const callbackRes = await request(app)
+      .get(`/api/auth/github/callback?code=test-auth-code&state=${stateValue}`);
+
+    expect(callbackRes.status).toBe(302);
+    const redirectUrl = new URL(callbackRes.headers.location);
+    expect(redirectUrl.origin + redirectUrl.pathname).toBe("http://localhost:3002/pj/admin");
+    expect(redirectUrl.searchParams.get("auth")).toBe("success");
+    expect(redirectUrl.searchParams.get("connected")).toBe("github");
+  });
+
   it("state is single-use (replay rejected)", async () => {
     const app = await createTestApp();
 


### PR DESCRIPTION
## Summary
- preserve post-OAuth return targets for the PJ admin/operator flows and persist them in the OAuth state store
- tighten redirect validation so return targets only resolve to configured application origins instead of request-controlled host/referrer values
- refresh the admin/operator copy and add initial LogicOS routing/id scaffolding files
- fix `/api/me` local-user lookup to use the controlled data directory

## Review notes
- fixed a security issue discovered during review: the original redirect-target allowlist trusted request-derived origins, which could be abused for open redirects
- the new `ids.js`, `router.js`, and `001_records.sql` files are scaffolding only in this PR and are not yet wired into runtime flows

## Validation
- `cd n8drive && corepack pnpm run test:core -- --runInBand`
- `cd n8drive && corepack pnpm run test:pj -- test/oauth-redirect.test.ts`
- `cd n8drive && corepack pnpm run typecheck`
- `cd n8drive && corepack pnpm --filter @publiclogic/logic-commons run test -- test/oauth-factory.test.ts test/state-store.test.ts`
- `cd n8drive && corepack pnpm --filter @publiclogic/puddlejumper run test -- test/oauth-redirect.test.ts`